### PR TITLE
Correct sun position calculation leap year

### DIFF
--- a/bifacialvf/sun.py
+++ b/bifacialvf/sun.py
@@ -378,7 +378,7 @@ def solarPos( year, month, day, hour, minute, lat, lng, tz ):
 			jday = julian(year,month,day);		# Get julian day of year
 			zulu = hour + minute/60.0 - tz;		# Convert local time to zulu time
 			delta = year - 1949;
-			leap = delta/4;
+			leap = (int)(delta/4);
 			jd = 32916.5 + delta*365 + leap + jday + zulu/24.0;
 			time = jd - 51545.0;	# Time in days referenced from noon 1 Jan 2000
 

--- a/bifacialvf/sun.py
+++ b/bifacialvf/sun.py
@@ -378,7 +378,7 @@ def solarPos( year, month, day, hour, minute, lat, lng, tz ):
 			jday = julian(year,month,day);		# Get julian day of year
 			zulu = hour + minute/60.0 - tz;		# Convert local time to zulu time
 			delta = year - 1949;
-			leap = (int)(delta/4);
+			leap = int(delta/4);
 			jd = 32916.5 + delta*365 + leap + jday + zulu/24.0;
 			time = jd - 51545.0;	# Time in days referenced from noon 1 Jan 2000
 


### PR DESCRIPTION
Within the solarPos calculation, the "leap" variable is being treated as a float, resulting in minor errors in solar position.  According to the reference paper, this parameter should only be taken as the integer portion: [link](https://ac.els-cdn.com/0038092X8890045X/1-s2.0-0038092X8890045X-main.pdf?_tid=5a116a8e-27bc-4351-b4ce-6ab2712d1978&acdnat=1531949617_5ad4437314d1a5c4b21a2ec117a6dc5f)

Please see section 2.1.