### PR TITLE
Change "facing west" criterion to allow small uncertainty in `sazm`

### DIFF
--- a/bifacialvf/bifacialvf.py
+++ b/bifacialvf/bifacialvf.py
@@ -548,7 +548,7 @@ def simulate(myTMY3, meta, writefiletitle=None, tilt=0, sazm=180,
                     # TODO: Modify so it works with axis_azm different of 0 
                     #        (sazm = 90 or 270 only)
                     if tracking == True:                                   
-                        if sazm == 270.0:
+                        if abs(sazm - 270.0) < 1e-3:
                             rangestart = sensorsy-1
                             rangeend = -1
                             steprange = -1


### PR DESCRIPTION
Closes #61 

Using the same reproducer as #61 with this branch, the swapping is gone:

![image](https://github.com/user-attachments/assets/33120ad4-87a6-40d9-b5c8-069e4c9fe790)

Disclaimer: I'm not very familiar at all with bifacialvf and have not evaluated the suitability of this fix beyond making the above plot.